### PR TITLE
Fix calling of static method _drawToCanvas

### DIFF
--- a/src/qr-scanner.js
+++ b/src/qr-scanner.js
@@ -290,7 +290,7 @@ export default class QrScanner {
         ]).then(([engine, image]) => {
             qrEngine = engine;
             let canvasContext;
-            [canvas, canvasContext] = this._drawToCanvas(image, scanRegion, canvas, disallowCanvasResizing);
+            [canvas, canvasContext] = QrScanner._drawToCanvas(image, scanRegion, canvas, disallowCanvasResizing);
 
             if (qrEngine instanceof Worker) {
                 if (!gotExternalWorker) {


### PR DESCRIPTION
## About
Fix call to `_drawToCanvas` which is static and therefore isn’t callable by `this`. Not sure how long this has been broken for but I couldn’t get the library to work at all without this change.

I checked and this is the only static method called using `this` instead of using the class itself