### PR TITLE
Fix deprecated example

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,21 @@ Create a `<video>` element where the web cam video stream should get rendered:
 
 #### 2. Create a QrScanner Instance
 ```js
-const qrScanner = new QrScanner(videoElem, result => console.log('decoded qr code:', result), {});
+// To enforce the use of the new api with detailed scan results, call the constructor with an options object, see below.
+const qrScanner = new QrScanner(
+    videoElem,
+    result => console.log('decoded qr code:', result),
+    { /* your options or returnDetailedScanResult: true if you're not specifying any other options */ },
+);
+
+// For backwards compatibility, omitting the options object will currently use the old api, returning scan results as
+// simple strings. This old api will be removed in the next major release, by which point the options object is then
+// also not required anymore to enable the new api.
+const qrScanner = new QrScanner(
+    videoElem,
+    result => console.log('decoded qr code:', result),
+    // No options provided. This will use the old api and is deprecated in the current version until next major version.
+);
 ```
 
 As an optional third parameter an options object can be provided.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Create a `<video>` element where the web cam video stream should get rendered:
 
 #### 2. Create a QrScanner Instance
 ```js
-const qrScanner = new QrScanner(videoElem, result => console.log('decoded qr code:', result));
+const qrScanner = new QrScanner(videoElem, result => console.log('decoded qr code:', result), {});
 ```
 
 As an optional third parameter an options object can be provided.


### PR DESCRIPTION
Without the options object, this triggers a deprecated type warning in VS Code:
<img width="1148" alt="Screen Shot 2022-05-31 at 3 40 13 PM" src="https://user-images.githubusercontent.com/176013/171271276-e461af8f-2a8b-45d6-9780-1fc8e507b137.png">

