### PR TITLE
Allow passing additional video track constraints

### DIFF
--- a/src/qr-scanner.ts
+++ b/src/qr-scanner.ts
@@ -70,6 +70,7 @@ class QrScanner {
     private _paused: boolean = false;
     private _flashOn: boolean = false;
     private _destroyed: boolean = false;
+    private _videoTrackConstraints?: MediaTrackConstraints;
 
     constructor(
         video: HTMLVideoElement,
@@ -84,6 +85,7 @@ class QrScanner {
             overlay?: HTMLDivElement,
             /** just a temporary flag until we switch entirely to the new api */
             returnDetailedScanResult?: true,
+            videoTrackConstraints?: MediaTrackConstraints,
         },
     );
     /** @deprecated */
@@ -117,6 +119,7 @@ class QrScanner {
             overlay?: HTMLDivElement,
             /** just a temporary flag until we switch entirely to the new api */
             returnDetailedScanResult?: true,
+            videoTrackConstraints?: MediaTrackConstraints,
         },
         canvasSizeOrCalculateScanRegion?: number | ((video: HTMLVideoElement) => QrScanner.ScanRegion),
         preferredCamera?: QrScanner.FacingMode | QrScanner.DeviceId,
@@ -164,6 +167,7 @@ class QrScanner {
         this._onLoadedMetaData = this._onLoadedMetaData.bind(this);
         this._onVisibilityChange = this._onVisibilityChange.bind(this);
         this._updateOverlay = this._updateOverlay.bind(this);
+        this._videoTrackConstraints = options.videoTrackConstraints;
 
         // @ts-ignore
         video.disablePictureInPicture = true;
@@ -869,7 +873,9 @@ class QrScanner {
 
         for (const constraints of [...constraintsWithCamera, ...constraintsWithoutCamera]) {
             try {
-                const stream = await navigator.mediaDevices.getUserMedia({ video: constraints, audio: false });
+                // Allows tweaking aspect ration, width, etc.
+                const finalContraints = { constraints, ...this._videoTrackConstraints }
+                const stream = await navigator.mediaDevices.getUserMedia({ video: finalContraints, audio: false });
                 // Try to determine the facing mode from the stream, otherwise use a guess or 'environment' as
                 // default. Note that the guess is not always accurate as Safari returns cameras of different facing
                 // mode, even for exact facingMode constraints.

--- a/src/qr-scanner.ts
+++ b/src/qr-scanner.ts
@@ -874,7 +874,7 @@ class QrScanner {
         for (const constraints of [...constraintsWithCamera, ...constraintsWithoutCamera]) {
             try {
                 // Allows tweaking aspect ration, width, etc.
-                const finalContraints = { constraints, ...this._videoTrackConstraints }
+                const finalContraints = { ...constraints, ...this._videoTrackConstraints }
                 const stream = await navigator.mediaDevices.getUserMedia({ video: finalContraints, audio: false });
                 // Try to determine the facing mode from the stream, otherwise use a guess or 'environment' as
                 // default. Note that the guess is not always accurate as Safari returns cameras of different facing


### PR DESCRIPTION
Hey hey,

Here's an attempt to allow passing additional video track constraints for the camera.
Use-case I have in mind: on a mobile device use a rear camera with a fixed 1:1 aspect ratio.

I'm not sure that's the best way to approach it, so any kind of feedback is welcome 🙏 
If we're happy with the approach, I'll also follow up with a documentation update.