### PR TITLE
Fix the scanImage() example code in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ If you want, you can stop scanning anytime and resume it by calling `start()` ag
 ### Single Image Scanning
 
 ```js
-QrScanner.scanImage(image)
+QrScanner.scanImage(image, { returnDetailedScanResult: true })
     .then(result => console.log(result))
     .catch(error => console.log(error || 'No QR code found.'));
 ```


### PR DESCRIPTION
The example code for scanImage() in the `README.md` calls a deprecated API. Therefore, an option to call a new API is given.